### PR TITLE
y2038: lib/cobalt: vdso: Fix runtime error detected on arm64

### DIFF
--- a/lib/cobalt/arch/arm64/include/asm/xenomai/time.h
+++ b/lib/cobalt/arch/arm64/include/asm/xenomai/time.h
@@ -12,7 +12,7 @@
 
 #define COBALT_VDSO_VERSION	"LINUX_2.6.39"
 
-#ifdef __USE_TIME_BITS64
+#if __USE_TIME_BITS64 && __TIMESIZE == 32
 #define COBALT_VDSO_GETTIME	"__vdso_clock_gettime64"
 #else
 #define COBALT_VDSO_GETTIME	"__kernel_clock_gettime"


### PR DESCRIPTION
Issue:  Runtime error on arm64 application:

        root@ls1046ardb:~# latency
        latency: __vdso_clock_gettime64 not found in vDSO: No such file or directory

Reason: Due to changed __USE_TIME_BITS64 behavior the vDSO init fails.

Fix: Adjust the vDSO configuration to correctly handle the selection of `__vdso_clock_gettime64` or `__kernel_clock_gettime` depending on the environment.

Impact: Resolves runtime errors on ARM64 platforms caused by incorrect vDSO function selection, ensuring compatibility with 64-bit and compatibility tasks.